### PR TITLE
feat: allow multiple commands per backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ cargo build --release
 **Config parse errors**
 - Validate your TOML syntax (e.g. [jsonformatter.org/toml-validator](https://jsonformatter.org/toml-validator))
 - `discord_token` and at least one `[[backends]]` entry are required
-- Each backend's `media` value must be unique
+- Every `media` command name must be unique, even across a backend's own aliases
 
 ## Migrating from the Clojure version
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -34,10 +34,14 @@ public_followup = true
 # ==============================================================================
 # BACKENDS
 # ==============================================================================
-# Each [[backends]] entry creates a Discord slash command: /request <media>
+# Each [[backends]] entry creates one or more Discord slash commands: /request <media>
 #
 # Key concepts:
-# - "media" is the slash command name (must be unique)
+# - "media" is the slash command name(s): a single string, or an array of strings (each must be unique)
+#
+# Examples:
+#   media = "movie"            -> Single command
+#   media = ["movie", "films"] -> Multiple commands pointing to the same backend
 # - You can have multiple backends of the same type (Radarr/Sonarr)
 # - Backends can point to the same instance with different settings
 #
@@ -156,7 +160,7 @@ api_key = "your_sonarr_api_key"
 # and enter their Discord User ID.
 
 # [[backends]]
-# media = "media"
+# media = ["media", "movies", "tv"]
 #
 # [backends.config.Seerr]
 # url = "http://localhost:5055"

--- a/doplarr/src/config.rs
+++ b/doplarr/src/config.rs
@@ -14,8 +14,25 @@ pub struct Config {
 
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
 pub struct Backend {
-    pub media: String,
+    #[serde(deserialize_with = "string_or_vec")]
+    pub media: Vec<String>,
     pub config: BackendConfig,
+}
+
+/// Deserialize String/Vec<String> to Vec<String>.
+fn string_or_vec<'de, D: serde::Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Vec<String>, D::Error> {
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum OneOrMany {
+        One(String),
+        Many(Vec<String>),
+    }
+    Ok(match OneOrMany::deserialize(deserializer)? {
+        OneOrMany::One(s) => vec![s],
+        OneOrMany::Many(v) => v,
+    })
 }
 
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
@@ -354,7 +371,7 @@ mod tests {
         let expected = Config {
             discord_token: "abc123".to_string(),
             backends: vec![Backend {
-                media: "movie".to_string(),
+                media: vec!["movie".to_string()],
                 config: BackendConfig::Radarr {
                     url: "http://1.2.3.4:7878".to_string(),
                     api_key: "abc123".to_string(),
@@ -369,6 +386,25 @@ mod tests {
         };
 
         assert_eq!(config, expected);
+    }
+
+    #[test]
+    fn backend_media_accepts_array_of_commands() {
+        let config: Config = toml::from_str(
+            r#"
+           discord_token = "abc123"
+
+           [[backends]]
+           media = ["movie", "film"]
+
+           [backends.config.Radarr]
+           url = "http://1.2.3.4:7878"
+           api_key = "abc123"
+        "#,
+        )
+        .unwrap();
+
+        assert_eq!(config.backends[0].media, vec!["movie", "film"]);
     }
 
     #[test]
@@ -391,7 +427,7 @@ mod tests {
         let expected = Config {
             discord_token: "abc123".to_string(),
             backends: vec![Backend {
-                media: "media".to_string(),
+                media: vec!["media".to_string()],
                 config: BackendConfig::Seerr {
                     url: "http://1.2.3.4:5055".to_string(),
                     api_key: "abc123".to_string(),

--- a/doplarr/src/main.rs
+++ b/doplarr/src/main.rs
@@ -57,6 +57,19 @@ fn user_facing_error(err: &anyhow::Error) -> String {
 
 type InteractionMap = Arc<Mutex<HashMap<uuid::Uuid, (mpsc::Sender<InteractionContinue>, Instant)>>>;
 
+/// Collect every backend command (across al backends), erroring if any name is claimed by more than one backend.
+fn distinct_media_types(backends: &[Backend]) -> anyhow::Result<HashSet<&str>> {
+    let mut media_types = HashSet::new();
+    if !backends
+        .iter()
+        .flat_map(|b| &b.media)
+        .all(|m| media_types.insert(m.as_str()))
+    {
+        bail!("There must only be one of each media type");
+    }
+    Ok(media_types)
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     // Parse command line args to get path to config file
@@ -69,7 +82,7 @@ async fn main() -> anyhow::Result<()> {
         return Ok(());
     };
 
-    // Setup logging with configured level
+    // Setup logging with configured levels
     let log_level = config.log_level.as_deref().unwrap_or("info");
     let env_filter =
         EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(log_level));
@@ -86,15 +99,7 @@ async fn main() -> anyhow::Result<()> {
         bail!("At least one media backend is required!");
     }
 
-    // Check that all media types are unique
-    let mut media_types = HashSet::new();
-    if !config
-        .backends
-        .iter()
-        .all(|x| media_types.insert(x.media.as_str()))
-    {
-        bail!("There must only be one of each media type");
-    }
+    let media_types = distinct_media_types(&config.backends)?;
 
     // Build the HTTP request client for backend calls with a reasonable timeout
     let backend_http = reqwest::Client::builder()
@@ -119,7 +124,9 @@ async fn main() -> anyhow::Result<()> {
                 Arc::new(Sportarr::connect(config.clone(), backend_http.clone()).await?)
             }
         };
-        backends.insert(media.as_str(), backend);
+        for m in media {
+            backends.insert(m.as_str(), backend.clone());
+        }
     }
 
     // We listen for interactions, plus guild events so we can register commands
@@ -404,4 +411,51 @@ async fn main() -> anyhow::Result<()> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use config::BackendConfig;
+
+    fn backend(media: &[&str]) -> Backend {
+        Backend {
+            media: media.iter().map(|s| s.to_string()).collect(),
+            config: BackendConfig::Sportarr {
+                url: "http://localhost".to_string(),
+                api_key: "key".to_string(),
+                quality_profile: None,
+            },
+        }
+    }
+
+    #[test]
+    fn distinct_media_types_allows_unique_commands() {
+        let backends = [backend(&["movie"]), backend(&["series"])];
+        let types = distinct_media_types(&backends).unwrap();
+
+        assert_eq!(types, HashSet::from(["movie", "series"]));
+    }
+
+    #[test]
+    fn distinct_media_types_allows_alias_on_same_backend() {
+        let backends = [backend(&["movie", "film"])];
+        let types = distinct_media_types(&backends).unwrap();
+
+        assert_eq!(types, HashSet::from(["movie", "film"]));
+    }
+
+    #[test]
+    fn distinct_media_types_errors_non_unique_commands() {
+        let backends = [backend(&["movie"]), backend(&["movie"])];
+
+        assert!(distinct_media_types(&backends).is_err());
+    }
+
+    #[test]
+    fn distinct_media_types_errors_non_unique_on_same_backend() {
+        let backends = [backend(&["movie", "movie"])];
+
+        assert!(distinct_media_types(&backends).is_err());
+    }
 }

--- a/doplarr/src/main.rs
+++ b/doplarr/src/main.rs
@@ -1,4 +1,4 @@
-use anyhow::bail;
+use anyhow::{Context, bail};
 use clap::Parser;
 use config::{Backend, BackendConfig};
 use discord::InteractionContinue;
@@ -56,6 +56,11 @@ fn user_facing_error(err: &anyhow::Error) -> String {
 }
 
 type InteractionMap = Arc<Mutex<HashMap<uuid::Uuid, (mpsc::Sender<InteractionContinue>, Instant)>>>;
+
+fn log_discord_auth_error<E: std::fmt::Display>(err: E) -> E {
+    error!("Discord API error: {err}");
+    err
+}
 
 /// Collect every backend command (across all backends), erroring if any name is claimed by more than one backend.
 fn distinct_media_types(backends: &[Backend]) -> anyhow::Result<HashSet<&str>> {
@@ -138,8 +143,17 @@ async fn main() -> anyhow::Result<()> {
 
     // Cache the application ID for repeated use later in the process.
     let application_id = {
-        let response = discord_http.current_user_application().await?;
-        response.model().await?.id
+        let response = discord_http
+            .current_user_application()
+            .await
+            .map_err(log_discord_auth_error)
+            .context("Failed to retrieve Discord application")?;
+        response
+            .model()
+            .await
+            .map_err(log_discord_auth_error)
+            .context("Failed to read Discord application response")?
+            .id
     };
 
     // Build the list of media types we'll register commands for

--- a/doplarr/src/main.rs
+++ b/doplarr/src/main.rs
@@ -57,7 +57,7 @@ fn user_facing_error(err: &anyhow::Error) -> String {
 
 type InteractionMap = Arc<Mutex<HashMap<uuid::Uuid, (mpsc::Sender<InteractionContinue>, Instant)>>>;
 
-/// Collect every backend command (across al backends), erroring if any name is claimed by more than one backend.
+/// Collect every backend command (across all backends), erroring if any name is claimed by more than one backend.
 fn distinct_media_types(backends: &[Backend]) -> anyhow::Result<HashSet<&str>> {
     let mut media_types = HashSet::new();
     if !backends


### PR DESCRIPTION
config can now also handle:
```toml
discord_token = "YOUR_DISCORD_BOT_TOKEN"

[[backends]]
media = ["series", "tv"] # "series" still works as well
[backends.config.Sonarr]
url = "http://localhost:8989"
api_key = "your_sonarr_api_key"
```

In the background both commands connect to the same MediaBackend instance.

Additionally added some context to logging when Discord API doesn't respond as expected.